### PR TITLE
Use a Cache in Front of Database

### DIFF
--- a/src/ILIAS/Cache.php
+++ b/src/ILIAS/Cache.php
@@ -1,0 +1,31 @@
+<?php
+/******************************************************************************
+ * An entity component framework for PHP.
+ *
+ * Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de>
+ *
+ * This software is licensed under GPLv3. You should have received a copy of
+ * the license along with the code.
+ */
+
+namespace CaT\Ente\ILIAS;
+
+/**
+ * Contract for a cache.
+ */
+interface Cache {
+    /**
+     * @return void
+     */
+    public function set(string $key, array $value);
+
+    /**
+     * @return array|null
+     */
+    public function get(string $key);
+
+    /**
+     * @return void
+     */
+    public function delete(string $key);
+}

--- a/src/ILIAS/Cache.php
+++ b/src/ILIAS/Cache.php
@@ -2,7 +2,7 @@
 /******************************************************************************
  * An entity component framework for PHP.
  *
- * Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de>
+ * Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de>
  *
  * This software is licensed under GPLv3. You should have received a copy of
  * the license along with the code.

--- a/src/ILIAS/ilCachedProviderDB.php
+++ b/src/ILIAS/ilCachedProviderDB.php
@@ -1,0 +1,104 @@
+<?php
+/******************************************************************************
+ * An entity component framework for PHP.
+ *
+ * Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de>
+ *
+ * This software is licensed under GPLv3. You should have received a copy of
+ * the license along with the code.
+ */
+
+namespace CaT\Ente\ILIAS;
+
+/**
+ * A database that stores ILIAS providers and uses a cache.
+ */
+class ilCachedProviderDB extends ilProviderDB {
+    /**
+     * @var Cache
+     */
+    protected $cache;
+
+    public function __construct(\ilDBInterface $ilDB, \ilTree $tree, \ilObjectDataCache $obj_cache, Cache $cache) {
+        parent::__construct($ilDB, $tree, $obj_cache);
+        $this->cache = $cache;
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function createSeparatedUnboundProvider(\ilObject $owner, $object_type, $class_name, $include_path) {
+        $this->cache->delete($owner->getId()."-$object_type-separated");
+        return parent::createSeparatedUnboundProvider($owner, $object_type, $class_name, $include_path);
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function createSharedUnboundProvider(\ilObject $owner, $object_type, $class_name, $include_path) {
+        $this->cache->delete($owner->getId()."-$object_type-shared");
+        return parent::createSharedUnboundProvider($owner, $object_type, $class_name, $include_path);
+    }
+
+    /**
+     * @inheritdocs
+     */
+    public function delete(UnboundProvider $provider, \ilObject $owner) {
+        $object_type = $provider->objectType();
+        $this->cache->delete($owner->getId()."-$object_type-separated");
+        $this->cache->delete($owner->getId()."-$object_type-shared");
+        parent::delete($provider, $owner);
+    }
+
+    /**
+     * Get the data of the separated unbound providers of the given nodes.
+     *
+     * @param   int[]       $node_ids
+     * @param   string      $object_type
+     * @param   string|null $component_type
+     * @return  array
+     */
+    protected function getSeperatedUnboundProviderDataOf($node_ids, string $object_type, string $component_type = null) {
+        if ($component_type !== null) {
+            return parent::getSeperatedUnboundProviderDataOf($node_ids, $object_type, $component_type);
+        }
+
+        $ret = [];
+        foreach($node_ids as $node_id) {
+            $key = "$node_id-$object_type-separated";
+            $data = $this->cache->get($key);
+            if ($data === null) {
+                $data = iterator_to_array(parent::getSeperatedUnboundProviderDataOf([$node_id], $object_type));
+                $this->cache->set($key, $data);
+            }
+            $ret[] = $data;
+        }
+        return call_user_func_array("array_merge", $ret);
+    }
+
+    /**
+     * Get the data of the shared unbound providers of the given nodes.
+     *
+     * @param   int[]       $node_ids
+     * @param   string      $object_type
+     * @param   string|null $component_type
+     * @return  array
+     */
+    protected function getSharedUnboundProviderDataOf($node_ids, string $object_type, string $component_type = null) {
+        if ($component_type !== null) {
+            return parent::getSharedUnboundProviderDataOf($node_ids, $object_type, $component_type);
+        }
+
+        $ret = [];
+        foreach($node_ids as $node_id) {
+            $key = "$node_id-$object_type-shared";
+            $data = $this->cache->get($key);
+            if ($data === null) {
+                $data = iterator_to_array(parent::getSharedUnboundProviderDataOf([$node_id], $object_type));
+                $this->cache->set($key, $data);
+            }
+            $ret[] = $data;
+        }
+        return call_user_func_array("array_merge", $ret);
+    }
+}

--- a/src/ILIAS/ilGlobalCache.php
+++ b/src/ILIAS/ilGlobalCache.php
@@ -1,0 +1,54 @@
+<?php
+/******************************************************************************
+ * An entity component framework for PHP.
+ *
+ * Copyright (c) 2018 Richard Klees <richard.klees@concepts-and-training.de>
+ *
+ * This software is licensed under GPLv3. You should have received a copy of
+ * the license along with the code.
+ */
+
+namespace CaT\Ente\ILIAS;
+
+/**
+ * Contract for a cache.
+ */
+class ilGlobalCache implements Cache {
+    /**
+     * @var \ilGlobalCache
+     */
+    protected $il_global_cache;
+
+    /**
+     * @var int|null
+     */
+    protected $ttl_in_seconds;
+
+    const PREFIX = "tms_ente_";
+
+    public function __construct(\ilGlobalCache $cache, int $ttl_in_seconds = null) {
+        $this->il_global_cache = $cache;
+        $this->ttl_in_seconds = $ttl_in_seconds;
+    }
+
+    /**
+     * @return void
+     */
+    public function set(string $key, array $value) {
+        return $this->il_global_cache->set(self::PREFIX.$key, $value);
+    }
+
+    /**
+     * @return array|null
+     */
+    public function get(string $key) {
+        return $this->il_global_cache->get(self::PREFIX.$key);
+    }
+
+    /**
+     * @return void
+     */
+    public function delete(string $key) {
+        $this->il_global_cache->delete(self::PREFIX.$key);
+    }
+}

--- a/src/ILIAS/ilProviderDB.php
+++ b/src/ILIAS/ilProviderDB.php
@@ -315,7 +315,7 @@ class ilProviderDB implements ProviderDB {
         while ($row = $this->ilDB->fetchAssoc($res)) {
             yield [
                 "id" => (int)$row["id"],
-                "owner" => $row["owner"],
+                "owner" => (int)$row["owner"],
                 "class_name" => $row["class_name"],
                 "include_path" => $row["include_path"]
             ];
@@ -331,12 +331,15 @@ class ilProviderDB implements ProviderDB {
      * @return  array
      */
     protected function getSharedUnboundProviderDataOf($node_ids, string $object_type, string $component_type = null) {
+        $to_int_list = function ($r) {
+            return array_map(function($v) { return (int)$v; }, explode(",", $r));
+        };
         $query = $this->buildSharedUnboundProviderQueryForObjects($node_ids, $object_type, $component_type);
         $res = $this->ilDB->query($query);
         while ($row = $this->ilDB->fetchAssoc($res)) {
             yield [
-                "owners" => explode(",", $row["owners"]),
-                "ids" => explode(",", $row["ids"]),
+                "owners" => $to_int_list($row["owners"]),
+                "ids" => $to_int_list($row["ids"]),
                 "class_name" => $row["class_name"],
                 "include_path" => $row["include_path"]
             ];

--- a/tests/ILIAS/ilCachedProviderDBTest.php
+++ b/tests/ILIAS/ilCachedProviderDBTest.php
@@ -1,0 +1,520 @@
+<?php
+/******************************************************************************
+ * An entity component framework for PHP.
+ *
+ * Copyright (c) 2017 Richard Klees <richard.klees@concepts-and-training.de>
+ *
+ * This software is licensed under GPLv3. You should have received a copy of
+ * the license along with the code.
+ */
+
+use CaT\Ente\ILIAS\SeparatedUnboundProvider;
+use CaT\Ente\ILIAS\UnboundProvider;
+use CaT\Ente\Provider;
+use CaT\Ente\ILIAS\ilCachedProviderDB;
+use CaT\Ente\ILIAS\ilProviderDB;
+use CaT\Ente\ILIAS\Cache;
+use CaT\Ente\Simple\AttachString;
+use CaT\Ente\Simple\AttachInt;
+
+if (!class_exists("ilObject")) {
+    require_once(__DIR__."/ilObject.php");
+}
+
+if (!interface_exists("ilDBInterface")) {
+    require_once(__DIR__."/ilDBInterface.php");
+}
+
+if (!interface_exists("ilTree")) {
+    require_once(__DIR__."/ilTree.php");
+}
+
+if (!interface_exists("ilObjectDataCache")) {
+    require_once(__DIR__."/ilObjectDataCache.php");
+}
+
+class Test_ilCachedProviderDB extends ilCachedProviderDB {
+    public $object_ref = [];
+	public $throws = false;
+    protected function buildObjectByRefId($ref_id) {
+		if ($this->throws) {
+			throw new \InvalidArgumentException();
+		}
+        assert(isset($this->object_ref[$ref_id]));
+        return $this->object_ref[$ref_id];
+    }
+    public $object_obj = [];
+    protected function buildObjectByObjId($obj_id) {
+		if ($this->throws) {
+			throw new \InvalidArgumentException();
+		}
+        assert(isset($this->object_obj[$obj_id]));
+        return $this->object_obj[$obj_id];
+    }
+    public $reference_ids = [];
+    protected function getAllReferenceIdsFor($obj_id) {
+        assert(isset($this->reference_ids[$obj_id]));
+        return $this->reference_ids[$obj_id];
+    }
+}
+
+class ILIAS_ilCachedProviderDBTest extends PHPUnit_Framework_TestCase {
+    protected function il_db_mock() {
+        return $this->createMock(\ilDBInterface::class);
+    }
+
+    public function il_tree_mock() {
+        return $this
+            ->getMockBuilder(\ilTree::class)
+            ->setMethods(["getSubTreeIds", "getNodePath"])
+            ->getMock();
+    }
+
+    public function il_object_data_cache_mock() {
+        return $this
+            ->getMockBuilder(\ilObjectDataCache::class)
+            ->setMethods(["preloadReferenceCache", "lookupObjId"])
+            ->getMock();
+    }
+
+    public function test_create() {
+        $il_db = $this->il_db_mock();
+
+        $owner = $this
+            ->getMockBuilder(\ilObject::class)
+            ->setMethods(["getId"])
+            ->getMock();
+
+        $owner_id = 42;
+        $owner
+            ->method("getId")
+            ->willReturn($owner_id);
+
+        $new_provider_id = 23;
+        $object_type = "crs";
+        $class_name = Test_SeparatedUnboundProvider::class;
+        $include_path = __DIR__."/SeparatedUnboundProviderTest.php";
+
+        $insert_provider =
+            [ "id" => ["integer", $new_provider_id]
+            , "owner" => ["integer", $owner_id]
+            , "object_type" => ["string", $object_type]
+            , "class_name" => ["string", $class_name]
+            , "include_path" => ["string", $include_path]
+			, "shared" => ["integer", 0]
+            ];
+
+        $insert_component_1 =
+            [ "id" => ["integer", $new_provider_id]
+            , "component_type" => ["string", AttachString::class]
+            ];
+
+        $insert_component_2 =
+            [ "id" => ["integer", $new_provider_id]
+            , "component_type" => ["string", AttachInt::class]
+            ];
+
+        $il_db
+            ->expects($this->exactly(3))
+            ->method("insert")
+            ->withConsecutive(
+                [ilProviderDB::PROVIDER_TABLE, $insert_provider],
+                [ilProviderDB::COMPONENT_TABLE, $insert_component_1],
+                [ilProviderDB::COMPONENT_TABLE, $insert_component_2]);
+
+        $il_db
+            ->expects($this->once())
+            ->method("nextId")
+            ->with(ilProviderDB::PROVIDER_TABLE)
+            ->willReturn($new_provider_id);
+
+        $cache = $this->createMock(Cache::class);
+
+        $cache
+            ->expects($this->once())
+            ->method("delete")
+            ->with("$owner_id-$object_type-separated");
+
+        $db = new ilCachedProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock(), $cache);
+        $unbound_provider = $db->createSeparatedUnboundProvider($owner, $object_type, $class_name, $include_path);
+
+        $this->assertInstanceOf(Test_SeparatedUnboundProvider::class, $unbound_provider);
+    }
+
+    public function test_delete() {
+        $il_db = $this->il_db_mock();
+
+        $owner = $this
+            ->getMockBuilder(\ilObject::class)
+            ->setMethods(["getId"])
+            ->getMock();
+
+        $owner_id = 42;
+        $owner
+            ->method("getId")
+            ->willReturn($owner_id);
+
+        $unbound_provider = $this->createMock(UnboundProvider::class);
+
+        $unbound_provider_id = 23;
+        $unbound_provider
+            ->expects($this->once())
+            ->method("idFor")
+            ->with($owner)
+            ->willReturn($unbound_provider_id);
+        $object_type = "otype";
+        $unbound_provider
+            ->method("objectType")
+            ->willReturn($object_type);
+
+        $il_db
+            ->expects($this->atLeastOnce())
+            ->method("quote")
+            ->with($unbound_provider_id, "integer")
+            ->willReturn("~$unbound_provider_id~");
+
+        $il_db
+            ->expects($this->exactly(2))
+            ->method("manipulate")
+            ->withConsecutive(
+                ["DELETE FROM ".ilProviderDB::PROVIDER_TABLE." WHERE id = ~$unbound_provider_id~"],
+                ["DELETE FROM ".ilProviderDB::COMPONENT_TABLE." WHERE id = ~$unbound_provider_id~"]);
+
+        $cache = $this->createMock(Cache::class);
+
+        $cache
+            ->expects($this->exactly(2))
+            ->method("delete")
+            ->withConsecutive(
+                ["$owner_id-$object_type-separated"],
+                ["$owner_id-$object_type-shared"]
+            );
+
+        $db = new ilCachedProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock(), $cache);
+        $db->delete($unbound_provider, $owner);
+    }
+
+    public function test_providersFor_no_cache() {
+        $il_db = $this->il_db_mock();
+        $il_tree = $this->il_tree_mock();
+        $il_cache = $this->il_object_data_cache_mock();
+
+        $object_ref_id = 42;
+        $object_type = "crs";
+        $object = $this
+            ->getMockBuilder(\ilObject::class)
+            ->setMethods(["getRefId", "getType"])
+            ->getMock();
+
+        $object
+            ->expects($this->atLeastOnce())
+            ->method("getRefId")
+            ->willReturn($object_ref_id);
+
+        $object
+            ->expects($this->atLeastOnce())
+            ->method("getType")
+            ->willReturn($object_type);
+
+        $sub_tree_id1 = 3;
+        $sub_tree_id2 = 14;
+        $sub_tree_ids = ["$sub_tree_id1", "$sub_tree_id2"];
+        $il_tree
+            ->expects($this->once())
+            ->method("getSubTreeIds")
+            ->with($object_ref_id)
+            ->willReturn($sub_tree_ids);
+
+		$tree_ids = array_merge([$object_ref_id], $sub_tree_ids);
+        $il_cache
+            ->expects($this->once())
+            ->method("preloadReferenceCache")
+            ->with($tree_ids);
+
+        $il_cache
+            ->expects($this->exactly(3))
+            ->method("lookupObjId")
+            ->withConsecutive([$tree_ids[0]],[$tree_ids[1]], [$tree_ids[2]])
+            ->will($this->onConsecutiveCalls($tree_ids[0], $tree_ids[1], $tree_ids[2]));
+
+
+        $class_name = Test_SeparatedUnboundProvider::class;
+        $include_path = __DIR__."/SeparatedUnboundProviderTest.php";
+
+        $cache = $this->createMock(Cache::class);
+        $cache
+            ->expects($this->exactly(6))
+            ->method("get")
+            ->withConsecutive(
+                ["$object_ref_id-$object_type-separated"],
+                ["$sub_tree_id1-$object_type-separated"],
+                ["$sub_tree_id2-$object_type-separated"],
+                ["$object_ref_id-$object_type-shared"],
+                ["$sub_tree_id1-$object_type-shared"],
+                ["$sub_tree_id2-$object_type-shared"]
+            )
+            ->willReturn(null);
+        $cache
+            ->expects($this->exactly(6))
+            ->method("set")
+            ->withConsecutive(
+                ["$object_ref_id-$object_type-separated", []],
+                ["$sub_tree_id1-$object_type-separated",
+                    [
+                        [
+                            "id" => 1,
+                            "owner" => $sub_tree_id1,
+                            "class_name" => $class_name,
+                            "include_path" => $include_path
+                        ]
+                    ]
+                ],
+                ["$sub_tree_id2-$object_type-separated",
+                    [
+                        [
+                            "id" => 2,
+                            "owner" => $sub_tree_id2,
+                            "class_name" => $class_name,
+                            "include_path" => $include_path
+                        ]
+                    ]
+                ],
+                ["$object_ref_id-$object_type-shared", []],
+                ["$sub_tree_id1-$object_type-shared", []],
+                ["$sub_tree_id2-$object_type-shared", []]
+            );
+
+        $il_db
+            ->expects($this->exactly(6))
+            ->method("in")
+            ->withConsecutive(
+                ["owner", [$object_ref_id], false, "integer"],
+                ["owner", [$sub_tree_id1], false, "integer"],
+                ["owner", [$sub_tree_id2], false, "integer"],
+                ["owner", [$object_ref_id], false, "integer"],
+                ["owner", [$sub_tree_id1], false, "integer"],
+                ["owner", [$sub_tree_id2], false, "integer"]
+            )
+            ->willReturnOnConsecutiveCalls("~IN1~", "~IN2~", "~IN3~", "~IN1~", "~IN2~", "~IN3~");
+        $il_db
+            ->expects($this->exactly(6))
+            ->method("quote")
+            ->with($object_type)
+            ->willReturn("~TYPE~");
+        $il_db
+            ->expects($this->exactly(6))
+            ->method("query")
+            ->withConsecutive
+                ( ["SELECT id, owner, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 0 AND ~IN1~ AND object_type = ~TYPE~"]
+                , ["SELECT id, owner, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 0 AND ~IN2~ AND object_type = ~TYPE~"]
+                , ["SELECT id, owner, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 0 AND ~IN3~ AND object_type = ~TYPE~"]
+                , ["SELECT GROUP_CONCAT(id SEPARATOR \",\") ids, GROUP_CONCAT(owner SEPARATOR \",\") owners, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 1 AND ~IN1~ AND object_type = ~TYPE~ GROUP BY class_name, include_path"]
+                , ["SELECT GROUP_CONCAT(id SEPARATOR \",\") ids, GROUP_CONCAT(owner SEPARATOR \",\") owners, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 1 AND ~IN2~ AND object_type = ~TYPE~ GROUP BY class_name, include_path"]
+                , ["SELECT GROUP_CONCAT(id SEPARATOR \",\") ids, GROUP_CONCAT(owner SEPARATOR \",\") owners, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 1 AND ~IN3~ AND object_type = ~TYPE~ GROUP BY class_name, include_path"]
+                )
+            ->willReturnOnConsecutiveCalls("R1", "R2", "R3", "R4", "R5", "R6");
+
+        $il_db
+            ->expects($this->exactly(8))
+            ->method("fetchAssoc")
+            ->withConsecutive(["R1"],["R2"],["R2"],["R3"],["R3"],["R4"],["R5"],["R6"])
+            ->will($this->onConsecutiveCalls(
+                null,
+                ["id" => 1, "owner" => $sub_tree_ids[0], "class_name" => $class_name, "include_path" => $include_path],
+                null,
+                ["id" => 2, "owner" => $sub_tree_ids[1], "class_name" => $class_name, "include_path" => $include_path],
+                null,
+                null,
+                null,
+                null));
+
+        $db = new Test_ilCachedProviderDB($il_db, $il_tree, $il_cache, $cache);
+
+        $owner_1 = $this
+            ->getMockBuilder(\ilObject::class)
+            ->getMock();
+        $db->object_ref[$sub_tree_ids[0]] = $owner_1;
+
+        $owner_2 = $this
+            ->getMockBuilder(\ilObject::class)
+            ->getMock();
+        $db->object_ref[$sub_tree_ids[1]] = $owner_2;
+
+        $providers = $db->providersFor($object);
+        $this->assertCount(2, $providers);
+
+        foreach ($providers as $provider) {
+            $this->assertInstanceOf(Provider::class, $provider);
+            $this->assertEquals($object, $provider->object());
+            $this->assertEquals($object_type, $provider->unboundProvider()->objectType());
+        }
+
+        list($provider1, $provider2) = $providers;
+        $this->assertEquals(1, $provider1->unboundProvider()->idFor($owner_1));
+        $this->assertEquals([$owner_1], $provider1->owners());
+
+        $this->assertEquals(2, $provider2->unboundProvider()->idFor($owner_2));
+        $this->assertEquals([$owner_2], $provider2->owners());
+    }
+
+    public function test_providersFor_with_cache() {
+        $il_db = $this->il_db_mock();
+        $il_tree = $this->il_tree_mock();
+        $il_cache = $this->il_object_data_cache_mock();
+
+        $object_ref_id = 42;
+        $object_type = "crs";
+        $object = $this
+            ->getMockBuilder(\ilObject::class)
+            ->setMethods(["getRefId", "getType"])
+            ->getMock();
+
+        $object
+            ->expects($this->atLeastOnce())
+            ->method("getRefId")
+            ->willReturn($object_ref_id);
+
+        $object
+            ->expects($this->atLeastOnce())
+            ->method("getType")
+            ->willReturn($object_type);
+
+        $sub_tree_id1 = 3;
+        $sub_tree_id2 = 14;
+        $sub_tree_ids = ["$sub_tree_id1", "$sub_tree_id2"];
+        $il_tree
+            ->expects($this->once())
+            ->method("getSubTreeIds")
+            ->with($object_ref_id)
+            ->willReturn($sub_tree_ids);
+
+		$tree_ids = array_merge([$object_ref_id], $sub_tree_ids);
+        $il_cache
+            ->expects($this->once())
+            ->method("preloadReferenceCache")
+            ->with($tree_ids);
+
+        $il_cache
+            ->expects($this->exactly(3))
+            ->method("lookupObjId")
+            ->withConsecutive([$tree_ids[0]],[$tree_ids[1]], [$tree_ids[2]])
+            ->will($this->onConsecutiveCalls($tree_ids[0], $tree_ids[1], $tree_ids[2]));
+
+
+        $class_name = Test_SeparatedUnboundProvider::class;
+        $include_path = __DIR__."/SeparatedUnboundProviderTest.php";
+
+        $cache = $this->createMock(Cache::class);
+
+        $cache
+            ->expects($this->exactly(6))
+            ->method("get")
+            ->withConsecutive(
+                ["$object_ref_id-$object_type-separated"],
+                ["$sub_tree_id1-$object_type-separated"],
+                ["$sub_tree_id2-$object_type-separated"],
+                ["$object_ref_id-$object_type-shared"],
+                ["$sub_tree_id1-$object_type-shared"],
+                ["$sub_tree_id2-$object_type-shared"]
+            )
+            ->willReturnOnConsecutiveCalls(
+                null,
+                [[
+                    "id" => 1,
+                    "owner" => $sub_tree_id1,
+                    "class_name" => $class_name,
+                    "include_path" => $include_path
+                ]],
+                null,
+                null,
+                [],
+                null
+            );
+
+        $cache
+            ->expects($this->exactly(4))
+            ->method("set")
+            ->withConsecutive(
+                ["$object_ref_id-$object_type-separated", []],
+                ["$sub_tree_id2-$object_type-separated",
+                    [
+                        [
+                            "id" => 2,
+                            "owner" => $sub_tree_id2,
+                            "class_name" => $class_name,
+                            "include_path" => $include_path
+                        ]
+                    ]
+                ],
+                ["$object_ref_id-$object_type-shared", []],
+                ["$sub_tree_id2-$object_type-shared", []]
+            );
+
+        $il_db
+            ->expects($this->exactly(4))
+            ->method("in")
+            ->withConsecutive(
+                ["owner", [$object_ref_id], false, "integer"],
+                ["owner", [$sub_tree_id2], false, "integer"],
+                ["owner", [$object_ref_id], false, "integer"],
+                ["owner", [$sub_tree_id2], false, "integer"]
+            )
+            ->willReturnOnConsecutiveCalls("~IN1~", "~IN3~", "~IN1~", "~IN3~");
+
+        $il_db
+            ->expects($this->exactly(4))
+            ->method("quote")
+            ->with($object_type)
+            ->willReturn("~TYPE~");
+
+        $il_db
+            ->expects($this->exactly(4))
+            ->method("query")
+            ->withConsecutive
+                ( ["SELECT id, owner, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 0 AND ~IN1~ AND object_type = ~TYPE~"]
+                , ["SELECT id, owner, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 0 AND ~IN3~ AND object_type = ~TYPE~"]
+                , ["SELECT GROUP_CONCAT(id SEPARATOR \",\") ids, GROUP_CONCAT(owner SEPARATOR \",\") owners, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 1 AND ~IN1~ AND object_type = ~TYPE~ GROUP BY class_name, include_path"]
+                , ["SELECT GROUP_CONCAT(id SEPARATOR \",\") ids, GROUP_CONCAT(owner SEPARATOR \",\") owners, class_name, include_path FROM ".ilProviderDB::PROVIDER_TABLE." WHERE shared = 1 AND ~IN3~ AND object_type = ~TYPE~ GROUP BY class_name, include_path"]
+                )
+            ->willReturnOnConsecutiveCalls("R1", "R2", "R5", "R6");
+
+        $il_db
+            ->expects($this->exactly(5))
+            ->method("fetchAssoc")
+            ->withConsecutive(["R1"],["R2"],["R2"],["R5"],["R6"])
+            ->will($this->onConsecutiveCalls(
+                null,
+                ["id" => 2, "owner" => $sub_tree_ids[1], "class_name" => $class_name, "include_path" => $include_path],
+                null,
+                null,
+                null));
+
+        $db = new Test_ilCachedProviderDB($il_db, $il_tree, $il_cache, $cache);
+
+        $owner_1 = $this
+            ->getMockBuilder(\ilObject::class)
+            ->getMock();
+        $db->object_ref[$sub_tree_ids[0]] = $owner_1;
+
+        $owner_2 = $this
+            ->getMockBuilder(\ilObject::class)
+            ->getMock();
+        $db->object_ref[$sub_tree_ids[1]] = $owner_2;
+
+        $providers = $db->providersFor($object);
+        $this->assertCount(2, $providers);
+
+        foreach ($providers as $provider) {
+            $this->assertInstanceOf(Provider::class, $provider);
+            $this->assertEquals($object, $provider->object());
+            $this->assertEquals($object_type, $provider->unboundProvider()->objectType());
+        }
+
+        list($provider1, $provider2) = $providers;
+        $this->assertEquals(1, $provider1->unboundProvider()->idFor($owner_1));
+        $this->assertEquals([$owner_1], $provider1->owners());
+
+        $this->assertEquals(2, $provider2->unboundProvider()->idFor($owner_2));
+        $this->assertEquals([$owner_2], $provider2->owners());
+    }
+}

--- a/tests/ILIAS/ilProviderDBTest.php
+++ b/tests/ILIAS/ilProviderDBTest.php
@@ -131,7 +131,7 @@ class ILIAS_ilProviderDBTest extends PHPUnit_Framework_TestCase {
             ->method("addIndex")
             ->with(ilProviderDB::PROVIDER_TABLE, ["shared"], "ids");
    
-        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock(), []);
+        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock());
         $db->createTables();
     }
 
@@ -186,7 +186,7 @@ class ILIAS_ilProviderDBTest extends PHPUnit_Framework_TestCase {
             ->with(ilProviderDB::PROVIDER_TABLE)
             ->willReturn($new_provider_id);
 
-        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock(), []);
+        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock());
         $unbound_provider = $db->createSeparatedUnboundProvider($owner, $object_type, $class_name, $include_path);
 
         $this->assertInstanceOf(Test_SeparatedUnboundProvider::class, $unbound_provider);
@@ -223,7 +223,7 @@ class ILIAS_ilProviderDBTest extends PHPUnit_Framework_TestCase {
                 ["DELETE FROM ".ilProviderDB::PROVIDER_TABLE." WHERE id = ~$unbound_provider_id~"],
                 ["DELETE FROM ".ilProviderDB::COMPONENT_TABLE." WHERE id = ~$unbound_provider_id~"]);
 
-        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock(), []);
+        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock());
         $db->delete($unbound_provider, $owner);
     }
 
@@ -300,7 +300,7 @@ class ILIAS_ilProviderDBTest extends PHPUnit_Framework_TestCase {
                 [ilProviderDB::COMPONENT_TABLE, $insert_component_3],
                 [ilProviderDB::COMPONENT_TABLE, $insert_component_4]);
 
-        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock(), []);
+        $db = new ilProviderDB($il_db, $this->il_tree_mock(), $this->il_object_data_cache_mock());
         $db->update($unbound_provider);
     }
 


### PR DESCRIPTION
This attempts to provide an performance enhancement for situations where many ILIAS-objects are involved by putting a cache in front of the SQL-database. The cache has an implementation based on ilGlobalCache. To accomplish the goal, refactorings in the original `ilProviderDB` were required. This also only attempts to cache information in ente-tables, not in general ILIAS tables.